### PR TITLE
Fixed repository link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"version": "0.3.4",
 	"publisher": "MrWhite",
 	"repository": {
-		"url": "https://github.com/owner/project/issues",
+		"url": "https://github.com/hugoblanc/capcode",
 		"type": "git"
 	},
 	"engines": {


### PR DESCRIPTION
Saw this extension on the VSCode marketplace and wanted to see the source code but the git repository link didn't work. So, I found it using GitHub search and fixed it.